### PR TITLE
Fix segfault when number of rows is equal to or exceeds BND_MAX_ROWS.

### DIFF
--- a/blendish.h
+++ b/blendish.h
@@ -2240,7 +2240,7 @@ static void bndCaretPosition(NVGcontext *ctx, float x, float y,
     int *cr, float *cx, float *cy) {
     static NVGglyphPosition glyphs[BND_MAX_GLYPHS];
     int r,nglyphs;
-    for (r=0; r < nrows && rows[r].end < caret; ++r);
+    for (r=0; r < nrows-1 && rows[r].end < caret; ++r);
     *cr = r;
     *cx = x;
     *cy = y-lineHeight-desc + r*lineHeight;


### PR DESCRIPTION
Fixes Rack issue #[435](https://github.com/VCVRack/Rack/issues/435).